### PR TITLE
Allow multibyte keys and values

### DIFF
--- a/eredis.el
+++ b/eredis.el
@@ -99,7 +99,7 @@ as it first constructs a list of key value pairs then uses that to construct the
         (let ((req (format "*%d\r\n$%d\r\n%s\r\n" num-args (length command) command)))
           (dolist (item arguments)
             (setf item (eredis--stringify-numbers-and-symbols item))
-            (setf req (concat req (format "$%d\r\n%s\r\n" (length item) item))))
+            (setf req (concat req (format "$%d\r\n%s\r\n" (string-bytes item) item))))
           req)
       nil)))
 


### PR DESCRIPTION
Use string-bytes instead of length to allow multibyte keys and values to be properly handled by all redis commands. Before this change commands given multibyte input would fail because the constructed command would not be what redis expects.